### PR TITLE
Fixed download weight URL (from darknet/YOLO/ to darknet/YOLOv2/)

### DIFF
--- a/part1 - setup YOLO.ipynb
+++ b/part1 - setup YOLO.ipynb
@@ -79,7 +79,7 @@
    "source": [
     "# Step 4 - Download a weights file\n",
     "\n",
-    "- Download the YOLOv2 608x608 weights file here (https://pjreddie.com/darknet/yolo/)\n",
+    "- Download the YOLOv2 608x608 weights file here (https://pjreddie.com/darknet/yolov2/)\n",
     "- NOTE: there are other weights files you can try if you like\n",
     "- create a ```bin``` folder within the ```darkflow-master``` folder\n",
     "- put the weights file in the bin folder"
@@ -100,7 +100,7 @@
     "- use the command\n",
     "\n",
     "```python\n",
-    "python flow --model cfg/yolo.cfg --load bin/yolo.weights --demo videofile.mp4 --gpu 1.0 --saveVideo\n",
+    "python flow --model cfg/yolo.cfg --load bin/yolov2.weights --demo videofile.mp4 --gpu 1.0 --saveVideo\n",
     "```\n",
     "\n",
     "```videofile.mp4``` is the name of your video.\n",


### PR DESCRIPTION
Since YOLOv3 came out, the URL to download the weights has changed from https://pjreddie.com/darknet/yolo/ to https://pjreddie.com/darknet/yolov2/. Also, the 606x606 weight file is now called yolov2.weights when downloaded! This pull request only fixes those two lines that need to be updated because of YOLOv3 release.

Summary:

- Fixed URL

- Fixed File Name